### PR TITLE
Migrate/to 3.5

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "docxToJats"]
 	path = docxToJats
-	url = git@github.com:sedici/docxToJats.git
+	url = https://github.com/Vitaliy-1/docxToJats.git

--- a/DocxToJatsPlugin.php
+++ b/DocxToJatsPlugin.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @file plugins/generic/docxConverter/DocxConverterPlugin.php
+ * @file plugins/generic/docxConverter/DocxToJatsPlugin.php
  *
  * Copyright (c) 2014-2019 Simon Fraser University Library
  * Copyright (c) 2003-2019 John Willinsky
@@ -12,6 +12,8 @@
 
  namespace APP\plugins\generic\docxConverter;
 
+ use APP\plugins\generic\docxConverter\classes\migration\upgrade\updateDocxConverterPluginName;
+
  use PKP\plugins\GenericPlugin;
  use PKP\linkAction\LinkAction;
  use PKP\linkAction\request\AjaxModal;
@@ -20,7 +22,7 @@
  use PKP\plugins\Hook;
  use APP\facades\Repo;
 
-class DocxConverterPlugin extends GenericPlugin {
+class DocxToJatsPlugin extends GenericPlugin {
 	/**
 	 * @copydoc Plugin::getDisplayName()
 	 */
@@ -157,8 +159,16 @@ class DocxConverterPlugin extends GenericPlugin {
         ];
     }
 
+	/**
+    * @copydoc Plugin::getInstallMigration()
+    */
+    public function getInstallMigration(): updateDocxConverterPluginName
+    {
+        return new updateDocxConverterPluginName();
+    }
+
 }
 
 if (!PKP_STRICT_MODE) {
-    class_alias('APP\plugins\generic\docxConverter\DocxConverterPlugin', '\DocxConverterPlugin');
+    class_alias('APP\plugins\generic\docxConverter\DocxToJatsPlugin', '\DocxToJatsPlugin');
 }

--- a/classes/migration/upgrade/updateDocxConverterPluginName.php
+++ b/classes/migration/upgrade/updateDocxConverterPluginName.php
@@ -27,6 +27,50 @@ class updateDocxConverterPluginName extends Migration
      */
     public function up(): void
     {
+        $product = 'docxConverter';
+        $oldValue = 'DocxToJatsPlugin';
+        $newValue = 'DocxConverterPlugin';
+
+        /** plugin_settings */
+
+        $upgradeRequired = DB::table('plugin_settings')
+            ->where(DB::raw('LOWER(plugin_name)'), '=', strtolower($oldValue))
+            ->count();
+
+        if ($upgradeRequired > 0) {
+            // Get all plugin settings and clear duplicates
+            $records = DB::table('plugin_settings')
+                ->where(DB::raw('LOWER(plugin_name)'), strtolower($oldValue))
+                ->orderBy(DB::raw('LOWER(plugin_name)'), 'desc')
+                ->get()
+                ->keyBy('context_id');
+
+            // Delete the old settings
+            DB::table('plugin_settings')
+                ->where(DB::raw('LOWER(plugin_name)'), strtolower($oldValue))
+                ->delete();
+
+            // Insert the settings with the correct plugin name
+            foreach ($records as $record) {
+                DB::table('plugin_settings')->insert(
+                    [
+                        'plugin_name' => strtolower($newValue),
+                        'context_id' => $record->context_id,
+                        'setting_name' => $record->setting_name,
+                        'setting_value' => $record->setting_value,
+                        'setting_type' => $record->setting_type
+                    ]
+                );
+            }
+        }
+
+        /** versions */
+
+        DB::table('versions')
+            ->where(DB::raw('LOWER(product_type)'), 'plugins.generic')
+            ->where(DB::raw('LOWER(product)'), strtolower($product))
+            ->where(DB::raw('LOWER(product_class_name)'), strtolower($oldValue))
+            ->update(['product_class_name' => $newValue]);
     }
 
     /**

--- a/classes/migration/upgrade/updateDocxConverterPluginName.php
+++ b/classes/migration/upgrade/updateDocxConverterPluginName.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @file plugins/generic/docxConverter/classes/migration/upgrade/updateDocxConverterPluginName.php
+ *
+ * Copyright (c) 2025 TIB Hannover
+ * Copyright (c) 2025 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class updateDocxConverterPluginName
+ *
+ * @ingroup plugins_generic_docxconverter
+ *
+ * @brief Fix the plugin name in plugin settings for the Portico export plugin.
+ */
+
+namespace APP\plugins\generic\docxConverter\classes\migration\upgrade;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use PKP\install\DowngradeNotSupportedException;
+
+class updateDocxConverterPluginName extends Migration
+{
+    /**
+     * Run the migration.
+     */
+    public function up(): void
+    {
+    }
+
+    /**
+     * Rollback the migration.
+     */
+    public function down(): void
+    {
+        throw new DowngradeNotSupportedException();
+    }
+}

--- a/classes/migration/upgrade/updateDocxConverterPluginName.php
+++ b/classes/migration/upgrade/updateDocxConverterPluginName.php
@@ -27,50 +27,6 @@ class updateDocxConverterPluginName extends Migration
      */
     public function up(): void
     {
-        $product = 'docxConverter';
-        $oldValue = 'DocxToJatsPlugin';
-        $newValue = 'DocxConverterPlugin';
-
-        /** plugin_settings */
-
-        $upgradeRequired = DB::table('plugin_settings')
-            ->where(DB::raw('LOWER(plugin_name)'), '=', strtolower($oldValue))
-            ->count();
-
-        if ($upgradeRequired > 0) {
-            // Get all plugin settings and clear duplicates
-            $records = DB::table('plugin_settings')
-                ->where(DB::raw('LOWER(plugin_name)'), strtolower($oldValue))
-                ->orderBy(DB::raw('LOWER(plugin_name)'), 'desc')
-                ->get()
-                ->keyBy('context_id');
-
-            // Delete the old settings
-            DB::table('plugin_settings')
-                ->where(DB::raw('LOWER(plugin_name)'), strtolower($oldValue))
-                ->delete();
-
-            // Insert the settings with the correct plugin name
-            foreach ($records as $record) {
-                DB::table('plugin_settings')->insert(
-                    [
-                        'plugin_name' => strtolower($newValue),
-                        'context_id' => $record->context_id,
-                        'setting_name' => $record->setting_name,
-                        'setting_value' => $record->setting_value,
-                        'setting_type' => $record->setting_type
-                    ]
-                );
-            }
-        }
-
-        /** versions */
-
-        DB::table('versions')
-            ->where(DB::raw('LOWER(product_type)'), 'plugins.generic')
-            ->where(DB::raw('LOWER(product)'), strtolower($product))
-            ->where(DB::raw('LOWER(product_class_name)'), strtolower($oldValue))
-            ->update(['product_class_name' => $newValue]);
     }
 
     /**

--- a/index.php
+++ b/index.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @file plugins/generic/docxConverter/index.php
+ *
+ * Copyright (c) 2014-2019 Simon Fraser University Library
+ * Copyright (c) 2003-2019 John Willinsky
+ * Distributed under the GNU GPL v2.
+ *
+ * @brief wrapper for driver plugin
+ */
+
+require_once('DocxToJatsPlugin.php');
+
+return new DocxToJatsPlugin();

--- a/version.xml
+++ b/version.xml
@@ -18,5 +18,5 @@
 	<release>1.1.1.0</release>
 	<date>2021-05-22</date>
 	<lazy-load>1</lazy-load>
-	<class>DocxConverterPlugin</class>
+	<class>DocxToJatsPlugin</class>
 </version>


### PR DESCRIPTION
Este PR actualiza la URL del submódulo para redirigirlo al repositorio de Vitaliy, incorpora los archivos de migración correspondientes junto con la modificación de version.xml, y agrega el script updateDocxConverterPluginName.php y se restaura el nombre interno del plugin a su estado original.